### PR TITLE
Use dagger-android's DaggerApplication and DaggerAppCompatActivity class

### DIFF
--- a/app/src/main/java/com/example/githubfirebaseissue/GithubApplication.kt
+++ b/app/src/main/java/com/example/githubfirebaseissue/GithubApplication.kt
@@ -4,24 +4,15 @@ import android.app.Activity
 import android.app.Application
 import com.example.githubfirebaseissue.di.component.DaggerApplicationComponent
 import dagger.android.AndroidInjector
+import dagger.android.DaggerApplication
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasActivityInjector
 import javax.inject.Inject
 
 
-class GithubApplication : Application(), HasActivityInjector {
+class GithubApplication : DaggerApplication() {
 
-    @Inject
-    lateinit var activityInjector: DispatchingAndroidInjector<Activity>
-
-    override fun activityInjector(): AndroidInjector<Activity> = activityInjector
-
-    override fun onCreate() {
-        super.onCreate()
-        DaggerApplicationComponent
-            .builder()
-            .application(this)
-            .build()
-            .inject(this)
+    override fun applicationInjector(): AndroidInjector<out DaggerApplication> {
+        return DaggerApplicationComponent.factory().create(this)
     }
 }

--- a/app/src/main/java/com/example/githubfirebaseissue/base/BaseActivity.kt
+++ b/app/src/main/java/com/example/githubfirebaseissue/base/BaseActivity.kt
@@ -8,21 +8,15 @@ import dagger.android.support.HasSupportFragmentInjector
 import dagger.android.DispatchingAndroidInjector
 import javax.inject.Inject
 import dagger.android.AndroidInjector
+import dagger.android.support.DaggerAppCompatActivity
 
 
-abstract class BaseActivity : AppCompatActivity(), HasSupportFragmentInjector {
-
-    @Inject
-    lateinit var fragmentDispatchingAndroidInjector: DispatchingAndroidInjector<Fragment>
+abstract class BaseActivity : DaggerAppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(getLayoutRes())
-    }
-
-    override fun supportFragmentInjector(): AndroidInjector<Fragment> {
-        return fragmentDispatchingAndroidInjector
     }
 
     fun replaceFragment(

--- a/app/src/main/java/com/example/githubfirebaseissue/base/BaseFragment.kt
+++ b/app/src/main/java/com/example/githubfirebaseissue/base/BaseFragment.kt
@@ -39,7 +39,7 @@ abstract class BaseFragment : Fragment() {
     }
 
     protected fun showErrorDialog(message: String, actionText: String) {
-        val dialog = Dialog(context!!)
+        val dialog = Dialog(requireContext())
         with(dialog) {
             requestWindowFeature(Window.FEATURE_NO_TITLE)
             setCancelable(false)

--- a/app/src/main/java/com/example/githubfirebaseissue/di/component/ApplicationComponent.kt
+++ b/app/src/main/java/com/example/githubfirebaseissue/di/component/ApplicationComponent.kt
@@ -20,13 +20,6 @@ import dagger.android.support.AndroidSupportInjectionModule
 )
 interface ApplicationComponent : AndroidInjector<GithubApplication> {
 
-    @Component.Builder
-    interface Builder {
-        @BindsInstance
-        fun application(application: GithubApplication): Builder
-
-        fun build(): ApplicationComponent
-    }
-
-    override fun inject(app: GithubApplication)
+    @Component.Factory
+    abstract class Builder: AndroidInjector.Factory<GithubApplication>
 }


### PR DESCRIPTION
These classes reduce the boilerplates  to a good extent. So, you don't have to manually implement  interfaces like HasActivityInjector or HasFragmentInjector!